### PR TITLE
feat: add state management and run actions using alarms

### DIFF
--- a/.changeset/warm-walls-teach.md
+++ b/.changeset/warm-walls-teach.md
@@ -1,0 +1,5 @@
+---
+'@repo/autofix': minor
+---
+
+feat: add state management and run actions using alarms

--- a/apps/autofix/package.json
+++ b/apps/autofix/package.json
@@ -25,12 +25,14 @@
 		"agents": "0.0.87",
 		"ai": "4.3.10",
 		"hono": "4.7.8",
+		"itty-time": "2.0.1",
 		"mime": "4.0.7",
 		"mock-fs": "5.5.0",
+		"ts-pattern": "5.7.0",
 		"tsx": "4.19.4",
 		"workers-ai-provider": "0.4.1",
-		"workers-tagged-logger": "0.10.0",
-		"zod": "3.24.4"
+		"workers-tagged-logger": "0.11.1",
+		"zod": "3.25.3"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "1.1.0",

--- a/apps/autofix/src/AutofixAgent.ts
+++ b/apps/autofix/src/AutofixAgent.ts
@@ -1,33 +1,414 @@
 import { Agent } from 'agents'
+import { datePlus } from 'itty-time'
+import { match } from 'ts-pattern'
+import { WithLogTags } from 'workers-tagged-logger/ts5'
+import { z } from 'zod/v4'
 
+import { logger } from './logger'
+
+import type { AgentContext } from 'agents'
 import type { Env } from './autofix.context'
 
-type State = {
+/**
+ * The status of the agent. This allows us to easily determine the
+ * state of the agent without inspecting the state of it's actions.
+ */
+const AgentStatuses = [
+	{ name: 'queued', description: 'Agent is queued and waiting to start.' },
+	{ name: 'running', description: 'Agent is running and processing actions.' },
+	{ name: 'stopped', description: 'Agent has stopped running.' },
+] as const satisfies Array<{
+	name: string
+	description: string
+}>
+
+const AgentStatus = z.enum(AgentStatuses.map((a) => a.name))
+type AgentStatus = z.infer<typeof AgentStatus>
+
+/**
+ * Actions/steps that the agent will take. In theory, we could
+ * support the agent taking these actions in any order, but
+ * right now they are taken in the order listed here.
+ */
+const AgentActions = [
+	{ name: 'initialize_container', description: 'Initialize the container for the repository.' },
+	{
+		name: 'detect_issues',
+		description: 'Detect issues in the project using build logs and configuration.',
+	},
+	{
+		name: 'fix_issues',
+		description: 'Attempt to fix detected issues using an AI model to generate a patch.',
+	},
+	{ name: 'commit_changes', description: 'Commit the applied fix to a new branch.' },
+	{
+		name: 'push_changes',
+		description: 'Push the new branch with the fix to the remote repository.',
+	},
+	{ name: 'create_pr', description: 'Create a pull request for the fix.' },
+] as const satisfies Array<{
+	name: string
+	description: string
+}>
+
+const AgentAction = z.enum(AgentActions.map((a) => a.name))
+type AgentAction = z.infer<typeof AgentAction>
+
+/**
+ * The status of an action that the agent is taking.
+ */
+const ActionStatuses = [
+	{ name: 'queued', description: 'Action is queued and waiting to start.' },
+	{ name: 'running', description: 'Action is running and processing.' },
+	{ name: 'stopped', description: 'Action has stopped running.' },
+] as const satisfies Array<{
+	name: string
+	description: string
+}>
+const ActionStatus = z.enum(ActionStatuses.map((a) => a.name))
+type ActionStatus = z.infer<typeof ActionStatus>
+
+type AgentState = {
 	repo: string
 	branch: string
+	agentStatus: AgentStatus
+	/**
+	 * We currently only support one action at a time, which is tracked here.
+	 */
+	currentAction: {
+		action: AgentAction
+		status: ActionStatus
+		/**
+		 * If the action failed, this will contain the error details.
+		 */
+		error?: { message: string }
+	}
 }
 
-export class AutofixAgent extends Agent<Env, State> {
-	// Define methods on the Agent:
+export { AutofixAgent }
+
+@EnsureAgentActions(AgentActions.map((a) => a.name))
+class AutofixAgent extends Agent<Env, AgentState> {
+	// Agents API reference:
 	// https://developers.cloudflare.com/agents/api-reference/agents-api/
-	//
-	// Every Agent has built in state via this.setState and this.sql
-	// Built-in scheduling via this.schedule
-	// Agents support WebSockets, HTTP requests, state synchronization and
-	// can run for seconds, minutes or hours: as long as the tasks need.
+
+	/**
+	 * Context logger with tags added in the constructor so that we
+	 * don't have to add tags in every method that's called via RPC.
+	 */
+	logger: typeof logger
+
+	/**
+	 * Promise for the current running action. This is used
+	 * to help us detect when a running action has timed out.
+	 */
+	private currentActionPromise: Promise<void> | undefined
+
+	constructor(ctx: AgentContext, env: Env) {
+		super(ctx, env)
+		this.logger = logger
+	}
 
 	/**
 	 * Start the agent
 	 */
-	async start({ repo, branch }: { repo: string; branch: string }) {
-		this.setState({ repo, branch })
-		// TODO: Trigger logic to start the fixing process for the repo
+	@WithLogTags({ source: 'AutofixAgent', handler: 'start' })
+	public async start({ repo, branch }: { repo: string; branch: string }) {
+		this.logger = logger.withTags({
+			state: {
+				repo,
+				branch,
+			},
+		})
+
+		this.logger.info(`[AutofixAgent] Queueing agent for repo: ${repo}, branch: ${branch}.`)
+		this.setState({
+			repo,
+			branch,
+			agentStatus: 'queued',
+			currentAction: { action: 'initialize_container', status: 'queued' },
+		})
+
+		// All further logic is handled in onAgentAlarm
+		await this.setNextAlarm()
+
+		return {
+			repo: this.state.repo,
+			branch: this.state.branch,
+			agentStatus: this.state.agentStatus,
+			currentAction: this.state.currentAction,
+			message: 'AutofixAgent queued.',
+		}
+	}
+
+	@WithLogTags({ source: 'AutofixAgent', handler: 'onAgentAlarm' })
+	async onAgentAlarm(): Promise<void> {
+		this.logger
+			.withFields({
+				agentState: this.state,
+			})
+			.info('[AutofixAgent] Alarm triggered.')
+
+		// handle Agent statuses
+		const isStopped = await match(this.state.agentStatus)
+			.returnType<Promise<boolean>>()
+			.with('queued', async () => {
+				this.logger.info('[AutofixAgent] Agent is queued. Transitioning to running.')
+				this.setState({
+					...this.state,
+					agentStatus: 'running',
+				})
+				await this.setNextAlarm()
+				return false
+			})
+			.with('running', async () => {
+				this.logger.info('[AutofixAgent] Agent is running. Setting next alarm.')
+				await this.setNextAlarm()
+				return false
+			})
+			.with('stopped', async () => {
+				this.logger.info('[AutofixAgent] Agent is stopped. Not setting next alarm.')
+				return true
+			})
+			.exhaustive()
+
+		if (isStopped) {
+			return
+		}
+
+		// Handle the case where the agent was interrupted by a DO restart.
+		// TODO: Add retries when this happens.
+		if (this.state.currentAction.status === 'running' && this.currentActionPromise === undefined) {
+			const interruptedActionName = this.state.currentAction.action
+			const interruptionMessage = `Action '${interruptedActionName}' was interrupted (possibly by a DO restart). Stopping agent.`
+			this.logger.warn(`[AutofixAgent] Interruption: ${interruptionMessage}`)
+			this.setState({
+				...this.state,
+				agentStatus: 'stopped',
+				currentAction: {
+					action: interruptedActionName,
+					status: 'stopped',
+					error: { message: interruptionMessage },
+				},
+			})
+			await this.setNextAlarm()
+			return
+		}
+
+		// agent actions
+		await match(this.state.currentAction)
+			// handle queued actions
+			.with({ action: 'initialize_container', status: 'queued' }, async () => {
+				await this.runActionHandler('initialize_container', () => this.handleInitializeContainer())
+				this.setQueued('detect_issues')
+			})
+			.with({ action: 'detect_issues', status: 'queued' }, async () => {
+				await this.runActionHandler('detect_issues', () => this.handleDetectIssues())
+				this.setQueued('fix_issues')
+			})
+			.with({ action: 'fix_issues', status: 'queued' }, async () => {
+				await this.runActionHandler('fix_issues', () => this.handleFixIssues())
+				this.setQueued('commit_changes')
+			})
+			.with({ action: 'commit_changes', status: 'queued' }, async () => {
+				await this.runActionHandler('commit_changes', () => this.handleCommitChanges())
+				this.setQueued('push_changes')
+			})
+			.with({ action: 'push_changes', status: 'queued' }, async () => {
+				await this.runActionHandler('push_changes', () => this.handlePushChanges())
+				this.setQueued('create_pr')
+			})
+			.with({ action: 'create_pr', status: 'queued' }, async () => {
+				await this.runActionHandler('create_pr', () => this.handleCreatePr())
+
+				this.logger.info('[AutofixAgent] Agent is done! Stopping.')
+				this.setState({
+					...this.state,
+					agentStatus: 'stopped',
+				})
+			})
+
+			// Only one alarm runs at a time, so if we got here, it means
+			// the agent failed to complete the previous action (or failed
+			// to mark it as stopped). In the future, we'll retry a few times.
+			// But for now, stopping the agent should be fine.
+			.with({ status: 'running' }, ({ action }) => {
+				this.logger.error(`[AutofixAgent] Action '${action}' is stuck in a loop. Stopping agent.`)
+				this.setState({
+					...this.state,
+					agentStatus: 'stopped',
+					currentAction: {
+						action,
+						status: 'stopped',
+						error: {
+							message: `Agent is stuck in a loop.`,
+						},
+					},
+				})
+			})
+
+			// If we get here, it means there are no further
+			// actions to run, so we can stop the agent.
+			.with({ status: 'stopped' }, ({ action }) => {
+				this.logger.info(
+					`[AutofixAgent] No action queued after ${action} was stopped. Stopping agent.`
+				)
+				this.setState({
+					...this.state,
+					agentStatus: 'stopped',
+				})
+			})
+			.exhaustive()
+	}
+
+	// ========================== //
+	// ======== Helpers ========= //
+	// ========================== //
+
+	/**
+	 * Schedules the next alarm for the agent.
+	 * @param nextAlarm Optional specific date for the next alarm. Default: 1 seconds from now.
+	 */
+	private async setNextAlarm(nextAlarm?: Date) {
+		const nextAlarmDate = nextAlarm ?? datePlus('1 seconds')
+		const task = await this.schedule(nextAlarmDate, 'onAgentAlarm', undefined)
+		this.logger
+			.withTags({
+				scheduledTaskId: task.id,
+			})
+			.info(
+				`[AutofixAgent] Next alarm set for ${nextAlarmDate.toISOString()} with taskId: "${task.id}"`
+			)
+	}
+
+	/**
+	 * Set the provided action to queued.
+	 */
+	private setQueued(actionName: AgentAction): void {
+		this.setState({
+			...this.state,
+			currentAction: { action: actionName, status: 'queued' },
+		})
+		this.logger.info(`[AutofixAgent] Action '${actionName}' queued.`)
+	}
+
+	/**
+	 * Set the provided action to running.
+	 */
+	private setRunning(actionName: AgentAction): void {
+		this.setState({
+			...this.state,
+			currentAction: { action: actionName, status: 'running' },
+		})
+		this.logger.info(`[AutofixAgent] Action '${actionName}' started.`)
+	}
+
+	/**
+	 * Set the provided action to stopped.
+	 *
+	 * @param error Optional error that occurred during the action.
+	 * Note: passing an error will cause the agent to stop.
+	 */
+	private setStopped(actionName: AgentAction, error?: Error | unknown): void {
+		if (error === undefined) {
+			this.setState({
+				...this.state,
+				currentAction: { action: actionName, status: 'stopped' },
+			})
+			this.logger.info(`[AutofixAgent] Action '${actionName}' stopped.`)
+		} else {
+			const errorMessage =
+				error instanceof Error ? error.message : 'Unknown error during action execution'
+			this.logger.error(
+				`[AutofixAgent] Action '${actionName}' FAILED. Error: ${errorMessage}. Agent stopping.`,
+				error instanceof Error ? error.stack : undefined
+			)
+			this.setState({
+				...this.state,
+				agentStatus: 'stopped', // Stop the agent if an action fails
+				currentAction: {
+					action: actionName,
+					status: 'stopped',
+					error: { message: errorMessage },
+				},
+			})
+		}
+	}
+
+	/**
+	 * Run a queued action. Automatically updates running/stopped statuses.
+	 */
+	private async runActionHandler(actionName: AgentAction, handlerFn: () => Promise<void>) {
+		this.setRunning(actionName)
+		// Track the current action's promise so that we can detect when
+		// the DO got inturrupted while it was running.
+		this.currentActionPromise = handlerFn()
+		try {
+			await this.currentActionPromise
+			this.setStopped(actionName)
+		} catch (e) {
+			this.setStopped(actionName, e)
+		} finally {
+			this.currentActionPromise = undefined
+		}
+	}
+
+	// =========================== //
+	// ===== Action Handlers ===== //
+	// =========================== //
+
+	async handleInitializeContainer(): Promise<void> {
+		this.logger.info('[AutofixAgent] Executing: handleInitializeContainer')
+		const { repo } = this.state
+		this.logger.info(`[AutofixAgent] Mock: Initializing container for repo: ${repo}`)
+
 		const userContainerId = this.env.USER_CONTAINER.idFromName(this.env.DEV_CLOUDFLARE_ACCOUNT_ID)
 		const userContainer = this.env.USER_CONTAINER.get(userContainerId)
 
 		// Start container, and destroy any active containers
 		await userContainer.container_initialize(repo)
+
+		this.logger.info('[AutofixAgent] Container initialized.')
 	}
+
+	async handleDetectIssues(): Promise<void> {
+		this.logger.info('[AutofixAgent] Executing: handleDetectIssues')
+		this.logger.info('[AutofixAgent] Mock: Detecting issues...')
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		this.logger.info('[AutofixAgent] Issue detection complete.')
+	}
+
+	async handleFixIssues(): Promise<void> {
+		this.logger.info('[AutofixAgent] Executing: handleFixIssues')
+		this.logger.info('[AutofixAgent] Mock: Fixing issues...')
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		this.logger.info('[AutofixAgent] Issue fixing complete.')
+	}
+
+	async handleCommitChanges(): Promise<void> {
+		this.logger.info('[AutofixAgent] Executing: handleCommitChanges')
+		this.logger.info('[AutofixAgent] Mock: Committing changes...')
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		this.logger.info('[AutofixAgent] Changes committed.')
+	}
+
+	async handlePushChanges(): Promise<void> {
+		this.logger.info('[AutofixAgent] Executing: handlePushChanges')
+		this.logger.info('[AutofixAgent] Mock: Pushing changes...')
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		this.logger.info('[AutofixAgent] Changes pushed.')
+	}
+
+	async handleCreatePr(): Promise<void> {
+		this.logger.info('[AutofixAgent] Executing: handleCreatePr')
+		this.logger.info('[AutofixAgent] Mock: Creating PR...')
+		await new Promise((resolve) => setTimeout(resolve, 100))
+		this.logger.info('[AutofixAgent] PR created.')
+	}
+
+	// ========================== //
+	// ==== Container Helpers ==== //
+	// ========================== //
 
 	async pingContainer() {
 		const userContainerId = this.env.USER_CONTAINER.idFromName(this.env.DEV_CLOUDFLARE_ACCOUNT_ID)
@@ -41,5 +422,40 @@ export class AutofixAgent extends Agent<Env, State> {
 		const userContainer = this.env.USER_CONTAINER.get(userContainerId)
 		const { resources } = await userContainer.container_ls()
 		return { resources }
+	}
+}
+
+// ========================== //
+// ======= Decorators ======= //
+// ========================== //
+
+/**
+ * Utility type to convert a string like "detect_issues" to "DetectIssues"
+ */
+type PascalCase<S extends string> = S extends `${infer P1}_${infer P2}`
+	? `${Capitalize<Lowercase<P1>>}${PascalCase<Capitalize<Lowercase<P2>>>}`
+	: Capitalize<S>
+
+/**
+ * Utility type to convert a string like "detect_issues" to "handleDetectIssues"
+ */
+type ActionToHandlerName<A extends string> = `handle${PascalCase<A>}`
+
+/**
+ * Decorator function to ensure the decorated class has handler methods for the given action
+ */
+export function EnsureAgentActions<const TActionStrings extends readonly string[]>(
+	_actionsToHandle: TActionStrings
+) {
+	return function <
+		Ctor extends new (...args: any[]) => {
+			[K in TActionStrings[number] as ActionToHandlerName<K>]: () => Promise<void>
+		} & { [key: string]: any },
+	>(value: Ctor, context: ClassDecoratorContext): Ctor | void {
+		if (context.kind !== 'class') {
+			throw new Error('EnsureAgentActions must be used as a class decorator.')
+		}
+		// We don't modify the class at all - only used for type checks.
+		return value
 	}
 }

--- a/apps/autofix/src/logger.ts
+++ b/apps/autofix/src/logger.ts
@@ -1,0 +1,6 @@
+import { WorkersLogger } from 'workers-tagged-logger'
+
+type LogTagHints = {
+	handler: string
+}
+export const logger = new WorkersLogger<LogTagHints>()

--- a/apps/autofix/tsconfig.json
+++ b/apps/autofix/tsconfig.json
@@ -1,3 +1,6 @@
 {
-	"extends": "@repo/typescript-config/workers.json"
+	"extends": "@repo/typescript-config/workers.json",
+	"compilerOptions": {
+		"experimentalDecorators": false
+	}
 }

--- a/apps/example-worker-echoback/package.json
+++ b/apps/example-worker-echoback/package.json
@@ -16,7 +16,7 @@
 	"dependencies": {
 		"@repo/hono-helpers": "workspace:*",
 		"hono": "4.7.8",
-		"workers-tagged-logger": "0.10.0"
+		"workers-tagged-logger": "0.11.1"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "0.8.26",

--- a/packages/hono-helpers/package.json
+++ b/packages/hono-helpers/package.json
@@ -14,8 +14,8 @@
 		"@hono/standard-validator": "0.1.2",
 		"hono": "4.7.8",
 		"http-codex": "0.5.4",
-		"workers-tagged-logger": "0.10.0",
-		"zod": "3.24.4"
+		"workers-tagged-logger": "0.11.1",
+		"zod": "3.25.3"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "0.8.26",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -27,7 +27,7 @@
 		"memoize-one": "6.0.0",
 		"ts-pattern": "5.7.0",
 		"tsx": "4.19.4",
-		"zod": "3.24.4",
+		"zod": "3.25.3",
 		"zx": "8.5.3"
 	},
 	"devDependencies": {

--- a/packages/typescript-config/workers.json
+++ b/packages/typescript-config/workers.json
@@ -21,6 +21,7 @@
 		"isolatedModules": true,
 		"allowSyntheticDefaultImports": true,
 		"forceConsistentCasingInFileNames": true,
+		"experimentalDecorators": true,
 		"strict": true,
 		"skipLibCheck": true
 	}

--- a/packages/workspace-dependencies/package.json
+++ b/packages/workspace-dependencies/package.json
@@ -46,7 +46,7 @@
 		"slugify": "1.6.6",
 		"wrangler": "4.14.3",
 		"yaml": "2.7.1",
-		"zod": "3.24.4",
+		"zod": "3.25.3",
 		"zx": "8.5.3"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 0.1.2(@standard-schema/spec@1.0.0)(hono@4.7.8)
       '@hono/zod-validator':
         specifier: 0.5.0
-        version: 0.5.0(hono@4.7.8)(zod@3.24.4)
+        version: 0.5.0(hono@4.7.8)(zod@3.25.3)
       '@octokit/rest':
         specifier: 21.1.1
         version: 21.1.1
@@ -73,16 +73,22 @@ importers:
         version: 0.0.87(@cloudflare/workers-types@4.20250508.0)(react@19.1.0)
       ai:
         specifier: 4.3.10
-        version: 4.3.10(react@19.1.0)(zod@3.24.4)
+        version: 4.3.10(react@19.1.0)(zod@3.25.3)
       hono:
         specifier: 4.7.8
         version: 4.7.8
+      itty-time:
+        specifier: 2.0.1
+        version: 2.0.1
       mime:
         specifier: 4.0.7
         version: 4.0.7
       mock-fs:
         specifier: 5.5.0
         version: 5.5.0
+      ts-pattern:
+        specifier: 5.7.0
+        version: 5.7.0
       tsx:
         specifier: 4.19.4
         version: 4.19.4
@@ -90,11 +96,11 @@ importers:
         specifier: 0.4.1
         version: 0.4.1
       workers-tagged-logger:
-        specifier: 0.10.0
-        version: 0.10.0
+        specifier: 0.11.1
+        version: 0.11.1
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: 3.25.3
+        version: 3.25.3
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.1.0
@@ -136,8 +142,8 @@ importers:
         specifier: 4.7.8
         version: 4.7.8
       workers-tagged-logger:
-        specifier: 0.10.0
-        version: 0.10.0
+        specifier: 0.11.1
+        version: 0.11.1
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 0.8.26
@@ -215,11 +221,11 @@ importers:
         specifier: 0.5.4
         version: 0.5.4
       workers-tagged-logger:
-        specifier: 0.10.0
-        version: 0.10.0
+        specifier: 0.11.1
+        version: 0.11.1
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: 3.25.3
+        version: 3.25.3
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 0.8.26
@@ -247,7 +253,7 @@ importers:
         version: 13.1.0(commander@13.1.0)
       '@jahands/cli-tools':
         specifier: 0.10.0
-        version: 0.10.0(@commander-js/extra-typings@13.1.0(commander@13.1.0))(commander@13.1.0)(typescript@5.8.2)(zod@3.24.4)(zx@8.5.3)
+        version: 0.10.0(@commander-js/extra-typings@13.1.0(commander@13.1.0))(commander@13.1.0)(typescript@5.8.2)(zod@3.25.3)(zx@8.5.3)
       '@types/node':
         specifier: 22.15.16
         version: 22.15.16
@@ -273,8 +279,8 @@ importers:
         specifier: 4.19.4
         version: 4.19.4
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: 3.25.3
+        version: 3.25.3
       zx:
         specifier: 8.5.3
         version: 8.5.3
@@ -303,8 +309,8 @@ importers:
         specifier: 2.7.1
         version: 2.7.1
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: 3.25.3
+        version: 3.25.3
       zx:
         specifier: 8.5.3
         version: 8.5.3
@@ -2677,6 +2683,9 @@ packages:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
 
+  itty-time@2.0.1:
+    resolution: {integrity: sha512-p612bgdK5YKgsg0nm8Wx4nYipHphdR+LD5yfDbIJOEEtkdrQyUcVDHlAkGmazCU4GaGx/6RhGrvucfOXifwxog==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4054,8 +4063,8 @@ packages:
   workers-ai-provider@0.4.1:
     resolution: {integrity: sha512-MnwDbdWrsuUJYJjMyPYpoGHVZe/gy9Z3GPtDx9OCysOhdkQfuc/0pBFKo62CL4+swbVunO518g2EsgAgELd2GQ==}
 
-  workers-tagged-logger@0.10.0:
-    resolution: {integrity: sha512-vnNApLMrE9bhPpt6/8Nw7VdoVa7IXOVBhXXwriMwX+/laXq4GLOz5ywYM0bUZRuWEFGJHjuq5sEvqwwNIQg33w==}
+  workers-tagged-logger@0.11.1:
+    resolution: {integrity: sha512-gajohNLEd2fYdkOdVrLBxBWXrmX95e0BBo+c6lJ1zCREkdtEzdJPhe23ahNLz8OcXrRYfoNfeE6BOJRZw5KeIw==}
 
   wrangler@4.14.3:
     resolution: {integrity: sha512-gY2n3cC8yb8VyaM0aY9fXX5AIah+VkGefmAHltUBgVpJaM4QXun6O85BydtTEljLL67JTyFyBDn/UPyg2WhESQ==}
@@ -4113,6 +4122,12 @@ packages:
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
+  zod@3.25.0-beta.20250516T044623:
+    resolution: {integrity: sha512-NjcetsH2m7GAPQV0hbYAXefUm8mqJf3W7dPBk41EHQrUcwmh5MCvOrIXXkl62CIKAFQyIgd4mukDEQVzBop9qw==}
+
+  zod@3.25.3:
+    resolution: {integrity: sha512-VGZqnyYNrl8JpEJRZaFPqeVNIuqgXNu4cXZ5cOb6zEUO1OxKbRnWB4UdDIXMmiERWncs0yDQukssHov8JUxykQ==}
+
   zx@8.5.3:
     resolution: {integrity: sha512-TsGLAt8Ngr4wDXLZmN9BT+6FWVLFbqdQ0qpXkV3tIfH7F+MgN/WUeSY7W4nNqAntjWunmnRaznpyxtJRPhCbUQ==}
     engines: {node: '>= 12.17.0'}
@@ -4122,57 +4137,57 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.4)':
+  '@ai-sdk/provider-utils@2.2.7(zod@3.25.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
-      zod: 3.24.4
+      zod: 3.25.3
 
-  '@ai-sdk/provider-utils@2.2.8(zod@3.24.4)':
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
-      zod: 3.24.4
+      zod: 3.25.3
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.24.4)':
+  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.25.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.24.4)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.3)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.3)
       react: 19.1.0
       swr: 2.3.3(react@19.1.0)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.24.4
+      zod: 3.25.3
 
-  '@ai-sdk/react@1.2.9(react@19.1.0)(zod@3.24.4)':
+  '@ai-sdk/react@1.2.9(react@19.1.0)(zod@3.25.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.2.8(zod@3.24.4)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.3)
+      '@ai-sdk/ui-utils': 1.2.8(zod@3.25.3)
       react: 19.1.0
       swr: 2.3.3(react@19.1.0)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.24.4
+      zod: 3.25.3
 
-  '@ai-sdk/ui-utils@1.2.11(zod@3.24.4)':
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.4)
-      zod: 3.24.4
-      zod-to-json-schema: 3.24.5(zod@3.24.4)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.3)
+      zod: 3.25.3
+      zod-to-json-schema: 3.24.5(zod@3.25.3)
 
-  '@ai-sdk/ui-utils@1.2.8(zod@3.24.4)':
+  '@ai-sdk/ui-utils@1.2.8(zod@3.25.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.4)
-      zod: 3.24.4
-      zod-to-json-schema: 3.24.5(zod@3.24.4)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.3)
+      zod: 3.25.3
+      zod-to-json-schema: 3.24.5(zod@3.25.3)
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -4608,10 +4623,10 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       hono: 4.7.8
 
-  '@hono/zod-validator@0.5.0(hono@4.7.8)(zod@3.24.4)':
+  '@hono/zod-validator@0.5.0(hono@4.7.8)(zod@3.25.3)':
     dependencies:
       hono: 4.7.8
-      zod: 3.24.4
+      zod: 3.25.3
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -4711,12 +4726,12 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@jahands/cli-tools@0.10.0(@commander-js/extra-typings@13.1.0(commander@13.1.0))(commander@13.1.0)(typescript@5.8.2)(zod@3.24.4)(zx@8.5.3)':
+  '@jahands/cli-tools@0.10.0(@commander-js/extra-typings@13.1.0(commander@13.1.0))(commander@13.1.0)(typescript@5.8.2)(zod@3.25.3)(zx@8.5.3)':
     dependencies:
       '@commander-js/extra-typings': 13.1.0(commander@13.1.0)
       commander: 13.1.0
       typescript: 5.8.2
-      zod: 3.24.4
+      zod: 3.25.3
       zx: 8.5.3
 
   '@jridgewell/gen-mapping@0.3.8':
@@ -4769,8 +4784,8 @@ snapshots:
       express-rate-limit: 7.5.0(express@5.1.0)
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
-      zod: 3.24.4
-      zod-to-json-schema: 3.24.5(zod@3.24.4)
+      zod: 3.25.3
+      zod-to-json-schema: 3.24.5(zod@3.25.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5245,13 +5260,13 @@ snapshots:
   agents@0.0.87(@cloudflare/workers-types@4.20250508.0)(react@19.1.0):
     dependencies:
       '@modelcontextprotocol/sdk': 1.11.2
-      ai: 4.3.15(react@19.1.0)(zod@3.24.4)
+      ai: 4.3.15(react@19.1.0)(zod@3.25.3)
       cron-schedule: 5.0.4
       nanoid: 5.1.5
       partyserver: 0.0.71(@cloudflare/workers-types@4.20250508.0)
       partysocket: 1.1.4
       react: 19.1.0
-      zod: 3.24.4
+      zod: 3.25.3
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - supports-color
@@ -5261,27 +5276,27 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@4.3.10(react@19.1.0)(zod@3.24.4):
+  ai@4.3.10(react@19.1.0)(zod@3.25.3):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.4)
-      '@ai-sdk/react': 1.2.9(react@19.1.0)(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.2.8(zod@3.24.4)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.3)
+      '@ai-sdk/react': 1.2.9(react@19.1.0)(zod@3.25.3)
+      '@ai-sdk/ui-utils': 1.2.8(zod@3.25.3)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 3.24.4
+      zod: 3.25.3
     optionalDependencies:
       react: 19.1.0
 
-  ai@4.3.15(react@19.1.0)(zod@3.24.4):
+  ai@4.3.15(react@19.1.0)(zod@3.25.3):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.24.4)
-      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.24.4)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.24.4)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.3)
+      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.25.3)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.3)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 3.24.4
+      zod: 3.25.3
     optionalDependencies:
       react: 19.1.0
 
@@ -6668,6 +6683,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.1: {}
+
+  itty-time@2.0.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -8123,7 +8140,9 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@cloudflare/workers-types': 4.20250508.0
 
-  workers-tagged-logger@0.10.0:
+  workers-tagged-logger@0.11.1:
+    dependencies:
+      zod: 3.25.0-beta.20250516T044623
     optionalDependencies:
       hono: 4.7.8
 
@@ -8167,12 +8186,16 @@ snapshots:
       mustache: 4.2.0
       stacktracey: 2.1.8
 
-  zod-to-json-schema@3.24.5(zod@3.24.4):
+  zod-to-json-schema@3.24.5(zod@3.25.3):
     dependencies:
-      zod: 3.24.4
+      zod: 3.25.3
 
   zod@3.22.3: {}
 
   zod@3.24.4: {}
+
+  zod@3.25.0-beta.20250516T044623: {}
+
+  zod@3.25.3: {}
 
   zx@8.5.3: {}


### PR DESCRIPTION
Refactors our Agent to run each step in an alarm (agents sdk exposes them via the "schedules" api)

Does not include retries yet as I wanted to keep the initial PR simple, but I think this is a decent pattern.