### PR TITLE
add docs MCP client. improve prompt. log tool calls

### DIFF
--- a/apps/autofix/worker-configuration.d.ts
+++ b/apps/autofix/worker-configuration.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-// Runtime types generated with workerd@1.20250507.0 2025-04-28 nodejs_compat
+// Runtime types generated with workerd@1.20250508.0 2025-04-28 nodejs_compat
 // Begin runtime types
 /*! *****************************************************************************
 Copyright (c) Cloudflare. All rights reserved.
@@ -5324,8 +5324,8 @@ declare namespace TailStream {
     }
     interface SpanOpen {
         readonly type: "spanOpen";
-        readonly op?: string;
-        readonly info?: FetchEventInfo | JsRpcEventInfo | Attribute[];
+        readonly name: string;
+        readonly info?: FetchEventInfo | JsRpcEventInfo | Attributes;
     }
     interface SpanClose {
         readonly type: "spanClose";
@@ -5349,7 +5349,7 @@ declare namespace TailStream {
     }
     interface Return {
         readonly type: "return";
-        readonly info?: FetchResponseInfo | Attribute[];
+        readonly info?: FetchResponseInfo | Attributes;
     }
     interface Link {
         readonly type: "link";
@@ -5359,21 +5359,23 @@ declare namespace TailStream {
         readonly spanId: string;
     }
     interface Attribute {
-        readonly type: "attribute";
         readonly name: string;
-        readonly value: string | string[] | boolean | boolean[] | number | number[];
+        readonly value: string | string[] | boolean | boolean[] | number | number[] | bigint | bigint[];
     }
-    type Mark = DiagnosticChannelEvent | Exception | Log | Return | Link | Attribute[];
+    interface Attributes {
+        readonly type: "attributes";
+        readonly info: Attribute[];
+    }
     interface TailEvent {
         readonly traceId: string;
         readonly invocationId: string;
         readonly spanId: string;
         readonly timestamp: Date;
         readonly sequence: number;
-        readonly event: Onset | Outcome | Hibernate | SpanOpen | SpanClose | Mark;
+        readonly event: Onset | Outcome | Hibernate | SpanOpen | SpanClose | DiagnosticChannelEvent | Exception | Log | Return | Link | Attributes;
     }
     type TailEventHandler = (event: TailEvent) => void | Promise<void>;
-    type TailEventHandlerName = "onset" | "outcome" | "hibernate" | "spanOpen" | "spanClose" | "diagnosticChannel" | "exception" | "log" | "return" | "link" | "attribute";
+    type TailEventHandlerName = "outcome" | "hibernate" | "spanOpen" | "spanClose" | "diagnosticChannel" | "exception" | "log" | "return" | "link" | "attributes";
     type TailEventHandlerObject = Record<TailEventHandlerName, TailEventHandler>;
     type TailEventHandlerType = TailEventHandler | TailEventHandlerObject;
 }


### PR DESCRIPTION
Example output:

### Project Description and Failure
The project "test" is a static website consisting of an `index.html` file. It failed to deploy because the `npx wrangler deploy` command didn't know where to find the website's files. Wrangler needs to be explicitly told where the static assets are located.

### Relevant Documentation
To deploy a static site with Cloudflare Workers using Wrangler, you need to configure an `assets` directory in your `wrangler.jsonc` (or `wrangler.toml`) file. This tells Wrangler where to find the static files to be deployed.

You can find more information in the Cloudflare documentation:
- [Static assets configuration](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets)
- [Get started with Static Assets](https://developers.cloudflare.com/workers/static-assets/get-started)

### Summary of the Fix
A `wrangler.jsonc` file was added to the root of the repository with the following content:
```jsonc
{
  "name": "test",
  "compatibility_date": "2025-05-16",
  "assets": {
    "directory": "./"
  }
}
```
This configuration informs Wrangler that the project is named "test", sets a compatibility date, and specifies that the static assets (like `index.html`) are located in the root directory of the project. This allows Wrangler to correctly find and deploy the static site.