### PR TITLE
fix: use correct name in changeset

### DIFF
--- a/.changeset/sour-buttons-press.md
+++ b/.changeset/sour-buttons-press.md
@@ -1,5 +1,5 @@
 ---
-'autofix-agent': minor
+'@repo/autofix': minor
 ---
 
 feat: scaffold autofix Worker


### PR DESCRIPTION
this is causing CI to fail. Missed this when renaming the package a while back